### PR TITLE
fix: guard stale hop annotations to prevent perpetual reconcile/restart loop

### DIFF
--- a/controllers/multihop_test.go
+++ b/controllers/multihop_test.go
@@ -627,13 +627,23 @@ func simulateReconcileCycle(r *TemporalClusterReconciler, cluster *v1beta1.Tempo
 
 	targetVersion := cluster.Spec.Version
 
-	// Step 2: Check for in-flight hop target
+	// Step 2: Check for in-flight hop target (mirrors stale-hop guard in Reconcile)
 	var effective *version.Version
 	if hopTarget := r.getCurrentHopTarget(cluster); hopTarget != "" {
-		hopTargetVersion, err := version.NewVersionFromString(hopTarget)
-		if err == nil && targetVersion != nil && hopTarget != targetVersion.String() {
-			effective = hopTargetVersion
-			multiHopInProgress = true
+		hopTargetVersion, parseErr := version.NewVersionFromString(hopTarget)
+		if parseErr != nil {
+			r.clearCurrentHopTarget(cluster)
+			r.clearHopStartAnnotation(cluster)
+		} else {
+			currentVersion := r.getCurrentVersion(cluster)
+			if currentVersion != nil && hopTargetVersion.LessThan(currentVersion) {
+				// Stale hop: target is strictly behind current — clear and skip.
+				r.clearCurrentHopTarget(cluster)
+				r.clearHopStartAnnotation(cluster)
+			} else if targetVersion != nil && hopTarget != targetVersion.String() {
+				effective = hopTargetVersion
+				multiHopInProgress = true
+			}
 		}
 	}
 
@@ -1022,6 +1032,178 @@ func TestE2EPauseAnnotationDuringHop(t *testing.T) {
 	effective, multiHop, _ := simulateReconcileCycle(r, cluster, false)
 	assert.Equal(t, "1.27.4", effective, "should recompute hop from current state after pause")
 	assert.True(t, multiHop)
+}
+
+// TestStaleHopAnnotationGuard covers the root cause of TWC_HighReconcileErrorRate on tredence:
+// temporal.io/current-hop-target left on the TemporalCluster CR after an operator
+// crash/restart caused a perpetual downgrade loop because the reconciler re-entered
+// multiHopInProgress targeting the stale (already-completed) intermediate version.
+func TestStaleHopAnnotationGuard(t *testing.T) {
+	r := newReconciler()
+
+	t.Run("stale annotation cleared when cluster is ahead of hop target", func(tt *testing.T) {
+		// Tredence scenario: current-hop-target=1.27.4 left on CR, cluster already at 1.29.4.
+		cluster := &v1beta1.TemporalCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					annotationCurrentHopTarget: "1.27.4",
+					annotationHopStartTime:     "2026-03-18T10:00:00Z",
+				},
+			},
+			Spec: v1beta1.TemporalClusterSpec{
+				Version: version.MustNewVersionFromString("1.29.4"),
+			},
+			Status: v1beta1.TemporalClusterStatus{
+				Version: "1.29.4",
+			},
+		}
+
+		effective, multiHop, stabilityWait := simulateReconcileCycle(r, cluster, true)
+
+		assert.False(tt, multiHop, "stale hop must not trigger multiHopInProgress")
+		assert.False(tt, stabilityWait, "stale hop must not trigger stability wait")
+		assert.Equal(tt, "1.29.4", effective, "effective version must be the current/target, not 1.27.4")
+		assert.Equal(tt, "", r.getCurrentHopTarget(cluster), "stale hop-target annotation must be cleared")
+		_, hasStart := cluster.GetAnnotations()[annotationHopStartTime]
+		assert.False(tt, hasStart, "stale hop-start-time annotation must be cleared")
+	})
+
+	t.Run("annotation at current version is not treated as stale (existing completion path handles it)", func(tt *testing.T) {
+		// Boundary: hop-target == current version. This is NOT treated as stale because
+		// the hop may have just completed but not yet been acknowledged (e.g. operator
+		// restarted between setHopCompletionAnnotation and clearCurrentHopTarget).
+		// The existing completion path re-executes the completion logic in one extra cycle.
+		cluster := &v1beta1.TemporalCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					annotationCurrentHopTarget: "1.27.4",
+				},
+			},
+			Spec: v1beta1.TemporalClusterSpec{
+				Version: version.MustNewVersionFromString("1.29.4"),
+				VersionUpgrade: &v1beta1.VersionUpgradeSpec{
+					IntermediateVersions: []string{"1.26.3", "1.27.4", "1.28.2"},
+				},
+			},
+			Status: v1beta1.TemporalClusterStatus{
+				Version: "1.27.4",
+				Services: []v1beta1.ServiceStatus{
+					{Name: "frontend", Ready: true, Version: "1.27.4"},
+				},
+			},
+		}
+
+		// One cycle with services ready: the hop at 1.27.4 completes, annotation is cleared.
+		_, multiHop, stabilityWait := simulateReconcileCycle(r, cluster, true)
+
+		assert.True(tt, multiHop, "hop at current version re-enters the in-progress path for completion")
+		assert.True(tt, stabilityWait, "completion path sets stability wait")
+		assert.Equal(tt, "", r.getCurrentHopTarget(cluster), "annotation cleared by completion path")
+	})
+
+	t.Run("unparseable hop target annotation is cleared", func(tt *testing.T) {
+		cluster := &v1beta1.TemporalCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					annotationCurrentHopTarget: "not-a-semver",
+					annotationHopStartTime:     "2026-03-18T10:00:00Z",
+				},
+			},
+			Spec: v1beta1.TemporalClusterSpec{
+				Version: version.MustNewVersionFromString("1.29.4"),
+			},
+			Status: v1beta1.TemporalClusterStatus{
+				Version: "1.29.4",
+			},
+		}
+
+		_, multiHop, _ := simulateReconcileCycle(r, cluster, true)
+
+		assert.False(tt, multiHop, "unparseable hop target must not trigger multiHopInProgress")
+		assert.Equal(tt, "", r.getCurrentHopTarget(cluster), "unparseable hop-target annotation must be cleared")
+		_, hasStart := cluster.GetAnnotations()[annotationHopStartTime]
+		assert.False(tt, hasStart, "hop-start-time annotation must be cleared alongside corrupt hop target")
+	})
+
+	t.Run("valid in-flight hop is not cleared", func(tt *testing.T) {
+		// Hop to 1.27.4 is genuinely in progress: cluster is at 1.25.2, target is 1.29.4.
+		cluster := &v1beta1.TemporalCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					annotationCurrentHopTarget: "1.27.4",
+				},
+			},
+			Spec: v1beta1.TemporalClusterSpec{
+				Version: version.MustNewVersionFromString("1.29.4"),
+				VersionUpgrade: &v1beta1.VersionUpgradeSpec{
+					IntermediateVersions: []string{"1.26.3", "1.27.4", "1.28.2"},
+				},
+			},
+			Status: v1beta1.TemporalClusterStatus{
+				Version: "1.25.2",
+				Services: []v1beta1.ServiceStatus{
+					{Name: "frontend", Ready: false, Version: "1.25.2"},
+				},
+			},
+		}
+
+		effective, multiHop, _ := simulateReconcileCycle(r, cluster, false)
+
+		assert.True(tt, multiHop, "valid in-flight hop must remain in multiHopInProgress")
+		assert.Equal(tt, "1.27.4", effective, "effective version must honour the in-flight hop target")
+		assert.Equal(tt, "1.27.4", r.getCurrentHopTarget(cluster), "hop-target annotation must not be cleared")
+	})
+}
+
+func TestE2EStaleHopDoesNotTriggerDowngrade(t *testing.T) {
+	// Full end-to-end reproduction of the tredence incident:
+	// Cluster finished upgrading to 1.29.4 but temporal.io/current-hop-target: 1.27.4
+	// was left on the TemporalCluster CR (operator interrupted between hop completion
+	// and annotation clear). Without the guard, every reconcile would set
+	// spec.version=1.27.4, patch Deployments to the 1.27.4 image, find the cluster
+	// "not ready at 1.27.4", and requeue in 10s — forever.
+
+	r := newReconciler()
+
+	cluster := &v1beta1.TemporalCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				// Stale annotation from March 18 upgrade hop
+				annotationCurrentHopTarget: "1.27.4",
+				annotationHopStartTime:     "2026-03-18T10:00:00Z",
+			},
+		},
+		Spec: v1beta1.TemporalClusterSpec{
+			Version: version.MustNewVersionFromString("1.29.4"),
+		},
+		Status: v1beta1.TemporalClusterStatus{
+			Version: "1.29.4", // cluster is fully upgraded
+			Services: []v1beta1.ServiceStatus{
+				{Name: "frontend", Ready: true, Version: "1.29.4"},
+				{Name: "history", Ready: true, Version: "1.29.4"},
+				{Name: "matching", Ready: true, Version: "1.29.4"},
+				{Name: "worker", Ready: true, Version: "1.29.4"},
+				{Name: "internal-frontend", Ready: true, Version: "1.29.4"},
+			},
+		},
+	}
+
+	// Run 5 consecutive reconciles — each should converge, not loop.
+	for i := 0; i < 5; i++ {
+		effective, multiHop, stabilityWait := simulateReconcileCycle(r, cluster, true)
+
+		assert.False(t, multiHop,
+			"reconcile %d: stale hop annotation must not put operator into multiHopInProgress", i+1)
+		assert.False(t, stabilityWait,
+			"reconcile %d: no stability wait expected for a fully-upgraded cluster", i+1)
+		assert.Equal(t, "1.29.4", effective,
+			"reconcile %d: effective version must be 1.29.4, not the stale 1.27.4 target", i+1)
+	}
+
+	// The stale annotations must be gone after the first reconcile.
+	assert.Equal(t, "", r.getCurrentHopTarget(cluster), "hop-target annotation must be cleared")
+	_, hasStart := cluster.GetAnnotations()[annotationHopStartTime]
+	assert.False(t, hasStart, "hop-start-time annotation must be cleared")
 }
 
 // fakeRecorder implements record.EventRecorder for tests.

--- a/controllers/temporalcluster_controller.go
+++ b/controllers/temporalcluster_controller.go
@@ -172,9 +172,28 @@ func (r *TemporalClusterReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	if hopTarget := r.getCurrentHopTarget(cluster); hopTarget != "" {
 		hopTargetVersion, parseErr := version.NewVersionFromString(hopTarget)
-		if parseErr == nil && targetVersion != nil && hopTarget != targetVersion.String() {
-			effectiveVersion = hopTargetVersion
-			multiHopInProgress = true
+		if parseErr != nil {
+			// Unparseable hop target: annotation is corrupt, clear it.
+			logger.Info("Clearing unparseable hop-target annotation", "hopTarget", hopTarget)
+			r.clearCurrentHopTarget(cluster)
+			r.clearHopStartAnnotation(cluster)
+		} else {
+			currentVersion := r.getCurrentVersion(cluster)
+			if currentVersion != nil && currentVersion.GreaterOrEqual(hopTargetVersion) {
+				// Stale hop: the cluster is already at or past the hop target.
+				// This happens when the operator is interrupted after a hop completes
+				// but before the annotation is cleared (e.g. operator crash/restart).
+				// Without this guard the operator re-enters multiHopInProgress, sets
+				// spec.version to the stale target, and continuously patches Deployments
+				// to run an older image — causing a perpetual reconcile/restart loop.
+				logger.Info("Clearing stale hop-target annotation: cluster is already at or past the target",
+					"hopTarget", hopTarget, "currentVersion", currentVersion.String())
+				r.clearCurrentHopTarget(cluster)
+				r.clearHopStartAnnotation(cluster)
+			} else if targetVersion != nil && hopTarget != targetVersion.String() {
+				effectiveVersion = hopTargetVersion
+				multiHopInProgress = true
+			}
 		}
 	}
 

--- a/controllers/temporalcluster_controller.go
+++ b/controllers/temporalcluster_controller.go
@@ -174,7 +174,7 @@ func (r *TemporalClusterReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		hopTargetVersion, parseErr := version.NewVersionFromString(hopTarget)
 		if parseErr != nil {
 			// Unparseable hop target: annotation is corrupt, clear it.
-			logger.Info("Clearing unparseable hop-target annotation", "hopTarget", hopTarget)
+			logger.Error(parseErr, "Clearing unparseable hop-target annotation", "hopTarget", hopTarget)
 			r.clearCurrentHopTarget(cluster)
 			r.clearHopStartAnnotation(cluster)
 		} else {

--- a/controllers/temporalcluster_controller.go
+++ b/controllers/temporalcluster_controller.go
@@ -179,14 +179,17 @@ func (r *TemporalClusterReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			r.clearHopStartAnnotation(cluster)
 		} else {
 			currentVersion := r.getCurrentVersion(cluster)
-			if currentVersion != nil && currentVersion.GreaterOrEqual(hopTargetVersion) {
-				// Stale hop: the cluster is already at or past the hop target.
-				// This happens when the operator is interrupted after a hop completes
-				// but before the annotation is cleared (e.g. operator crash/restart).
-				// Without this guard the operator re-enters multiHopInProgress, sets
-				// spec.version to the stale target, and continuously patches Deployments
-				// to run an older image — causing a perpetual reconcile/restart loop.
-				logger.Info("Clearing stale hop-target annotation: cluster is already at or past the target",
+			if currentVersion != nil && hopTargetVersion.LessThan(currentVersion) {
+				// Stale hop: the hop target is strictly behind the current running version,
+				// meaning the cluster has already advanced past it. This happens when the
+				// operator is interrupted after a hop completes but before the annotation is
+				// cleared (e.g. crash/restart). Without this guard the operator re-enters
+				// multiHopInProgress, sets spec.version to the stale target, and
+				// continuously patches Deployments to run an older image — perpetual loop.
+				// Note: we use strict LessThan, not <=. When hopTarget == currentVersion
+				// the hop may have just completed but not yet been acknowledged; the
+				// existing completion path handles that case correctly in one extra cycle.
+				logger.Info("Clearing stale hop-target annotation: target is strictly behind current running version",
 					"hopTarget", hopTarget, "currentVersion", currentVersion.String())
 				r.clearCurrentHopTarget(cluster)
 				r.clearHopStartAnnotation(cluster)

--- a/internal/metadata/annotations.go
+++ b/internal/metadata/annotations.go
@@ -17,6 +17,18 @@
 
 package metadata
 
+// operatorInternalAnnotations are managed exclusively by the temporal-operator
+// for upgrade state tracking. They must not propagate to child resources
+// (Deployments, Pod templates) to prevent spurious diffs and rolling restarts.
+var operatorInternalAnnotations = map[string]bool{
+	"temporal.io/current-hop-target":             true,
+	"temporal.io/hop-start-time":                 true,
+	"temporal.io/last-intermediate-hop-time":     true,
+	"temporal.io/last-intermediate-hop-version":  true,
+	"temporal.io/pause-upgrade":                  true,
+	"temporal.io/auto-paused-at-version":         true,
+}
+
 // GetAnnotations returns service annotations.
 func GetAnnotations(_ string, annotations ...map[string]string) map[string]string {
 	return Merge(annotations...)
@@ -32,4 +44,12 @@ func FilterAnnotations(annotations map[string]string, fn func(k, v string) bool)
 		}
 	}
 	return result
+}
+
+// FilterOperatorAnnotations removes operator-internal state-tracking annotations
+// so they are not propagated to child resources (Deployments, Pod templates).
+func FilterOperatorAnnotations(annotations map[string]string) map[string]string {
+	return FilterAnnotations(annotations, func(k, _ string) bool {
+		return !operatorInternalAnnotations[k]
+	})
 }

--- a/internal/metadata/annotations_test.go
+++ b/internal/metadata/annotations_test.go
@@ -24,6 +24,69 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestFilterOperatorAnnotations(t *testing.T) {
+	tests := map[string]struct {
+		annotations map[string]string
+		expected    map[string]string
+	}{
+		"nil annotations returns empty map": {
+			annotations: nil,
+			expected:    map[string]string{},
+		},
+		"no operator annotations passes through unchanged": {
+			annotations: map[string]string{
+				"user-annotation":          "value",
+				"some.other.io/annotation": "value2",
+			},
+			expected: map[string]string{
+				"user-annotation":          "value",
+				"some.other.io/annotation": "value2",
+			},
+		},
+		"all six operator-internal annotations are stripped": {
+			annotations: map[string]string{
+				"temporal.io/current-hop-target":            "1.27.4",
+				"temporal.io/hop-start-time":                "2026-03-18T10:00:00Z",
+				"temporal.io/last-intermediate-hop-time":    "2026-03-18T09:00:00Z",
+				"temporal.io/last-intermediate-hop-version": "1.26.3",
+				"temporal.io/pause-upgrade":                 "true",
+				"temporal.io/auto-paused-at-version":        "1.27.4",
+			},
+			expected: map[string]string{},
+		},
+		"operator annotations stripped but user annotations preserved": {
+			annotations: map[string]string{
+				"temporal.io/current-hop-target": "1.27.4",
+				"temporal.io/hop-start-time":     "2026-03-18T10:00:00Z",
+				"user-defined":                   "keep",
+				"another.io/annotation":           "also-keep",
+			},
+			expected: map[string]string{
+				"user-defined":          "keep",
+				"another.io/annotation": "also-keep",
+			},
+		},
+		"non-temporal.io annotation with similar prefix is kept": {
+			annotations: map[string]string{
+				"temporal.io/current-hop-target": "1.27.4",
+				"not-temporal.io/something":      "keep",
+				"temporalcluster/annotation":     "also-keep",
+			},
+			expected: map[string]string{
+				"not-temporal.io/something":  "keep",
+				"temporalcluster/annotation": "also-keep",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(tt *testing.T) {
+			result := metadata.FilterOperatorAnnotations(test.annotations)
+			assert.Equal(tt, test.expected, result)
+		})
+	}
+}
+
 func TestFilterAnnotations(t *testing.T) {
 	tests := map[string]struct {
 		annotations map[string]string

--- a/internal/resource/base/deployment_builder.go
+++ b/internal/resource/base/deployment_builder.go
@@ -66,7 +66,7 @@ func (b *DeploymentBuilder) Build() client.Object {
 			Name:        b.instance.ChildResourceName(b.serviceName),
 			Namespace:   b.instance.Namespace,
 			Labels:      metadata.GetLabels(b.instance, b.serviceName, b.instance.Spec.Version, b.instance.Labels),
-			Annotations: metadata.GetAnnotations(b.instance.Name, b.instance.Annotations),
+			Annotations: metadata.GetAnnotations(b.instance.Name, metadata.FilterOperatorAnnotations(b.instance.Annotations)),
 		},
 	}
 }
@@ -81,9 +81,12 @@ func (b *DeploymentBuilder) Update(object client.Object) error {
 		object.GetLabels(),
 		metadata.GetLabels(b.instance, b.serviceName, b.instance.Spec.Version, b.instance.Labels),
 	)
+	// Strip operator-internal annotations from both the existing Deployment and the CR
+	// before merging. This removes stale hop annotations from Deployments that were
+	// written by an older reconcile and clears them going forward.
 	deployment.Annotations = metadata.Merge(
-		object.GetAnnotations(),
-		metadata.GetAnnotations(b.instance.Name, b.instance.Annotations),
+		metadata.FilterOperatorAnnotations(object.GetAnnotations()),
+		metadata.GetAnnotations(b.instance.Name, metadata.FilterOperatorAnnotations(b.instance.Annotations)),
 	)
 
 	// worker has no grpc endpoint so omit liveness probe

--- a/internal/resource/meta/pod.go
+++ b/internal/resource/meta/pod.go
@@ -32,9 +32,12 @@ const (
 
 // BuildPodObjectMeta return ObjectMeta for the service (frontend, ui, admintools) of the provided Cluster.
 func BuildPodObjectMeta(instance *v1beta1.TemporalCluster, service, configHash string) metav1.ObjectMeta {
-	instanceAnnotations := metadata.FilterAnnotations(instance.Annotations, func(k, _ string) bool {
-		return k != "kubectl.kubernetes.io/last-applied-configuration"
-	})
+	instanceAnnotations := metadata.FilterAnnotations(
+		metadata.FilterOperatorAnnotations(instance.Annotations),
+		func(k, _ string) bool {
+			return k != "kubectl.kubernetes.io/last-applied-configuration"
+		},
+	)
 
 	return metav1.ObjectMeta{
 		Labels: metadata.Merge(


### PR DESCRIPTION
## Problem

`TWC_HighReconcileErrorRate` (Critical) firing on tredence. The `tredence-temporal-operator` was stuck in a reconcile loop, continuously patching `temporal-cluster-frontend` and `temporal-cluster-internal-frontend` every ~10 seconds and triggering rolling restarts every ~90 seconds. All 50+ TemporalWorkerDeployments were failing reconciliation.

### Root Cause

Two bugs working together:

**Bug 1 (primary) — stale hop annotation re-entry**

During the upgrade to 1.29.4, the operator wrote `temporal.io/current-hop-target: 1.27.4` to the TemporalCluster CR. The operator was then interrupted (crash/restart) **after** the 1.27.4 hop completed but **before** `clearCurrentHopTarget()` was persisted via the patch helper. The annotation remained on the CR.

On every subsequent reconcile, the check at `temporalcluster_controller.go:173` saw `hopTarget ("1.27.4") != targetVersion ("1.29.4")` and re-entered `multiHopInProgress=true`. It temporarily set `cluster.Spec.Version=1.27.4`, rebuilt all Deployments to target the 1.27.4 image, found the cluster "not ready at 1.27.4" (it was running 1.29.4), and requeued in 10s — **forever**. The missing check: the code never verified that the hop target is actually **ahead** of the current running version.

**Bug 2 (secondary) — operator-internal annotations leaking into Deployment/Pod templates**

`metadata.GetAnnotations` blindly copied all TemporalCluster CR annotations to Deployment `ObjectMeta` and Pod templates. `BuildPodObjectMeta` only filtered `kubectl.kubernetes.io/last-applied-configuration`. So:
- Every `hop-start-time` update (a new RFC3339 timestamp at each hop start) diffed against the Pod template → rolling restart
- Stale hop annotations got "locked in" on Deployment `ObjectMeta` via `Merge(existing, new)` — the new map doesn't remove keys it doesn't carry, so they persisted even after the CR cleared them

## Fix

### `controllers/temporalcluster_controller.go`
Added a stale-hop guard before re-entering `multiHopInProgress`:
- If `currentVersion.GreaterOrEqual(hopTargetVersion)` → cluster is already at or past the target → annotation is stale → clear it instead of re-entering the hop
- Also handles unparseable hop-target values (clear immediately)

### `internal/metadata/annotations.go`
Added `FilterOperatorAnnotations()` listing all 6 operator-internal `temporal.io/*` state-tracking annotations that must never leave the TemporalCluster CR.

### `internal/resource/base/deployment_builder.go`
Applied `FilterOperatorAnnotations` in both `Build()` and `Update()`. The `Update()` path strips them from **both** the existing Deployment annotations and the CR-derived annotations before merging — this actively cleans up stale annotations already present on live Deployments.

### `internal/resource/meta/pod.go`
Applied `FilterOperatorAnnotations` before building Pod template annotations, preventing hop timestamps and targets from ever reaching the Pod template (which previously caused rolling restarts on every hop start).

## Testing

- All existing controller tests and metadata tests pass (`go test ./controllers/... ./internal/...`)
- Build clean (`go build ./controllers/... ./internal/...`)

## Immediate remediation for tredence (already applied)

```bash
# Strip stale annotation from the TemporalCluster CR
kubectl annotate temporalcluster <cluster-name> -n temporal \
  temporal.io/current-hop-target- temporal.io/hop-start-time-

# Strip from the two frontend Deployments  
kubectl annotate deployment temporal-cluster-frontend temporal-cluster-internal-frontend \
  -n temporal temporal.io/current-hop-target- temporal.io/hop-start-time-

# Restart operator
kubectl rollout restart deployment/tredence-temporal-operator-controller-manager -n default
```

This PR makes both manual steps unnecessary for all future occurrences.