### PR TITLE
fix: only set Deployment replicas when CR sets Replicas (enable autoscaler ownership)

### DIFF
--- a/internal/resource/base/deployment_builder.go
+++ b/internal/resource/base/deployment_builder.go
@@ -337,7 +337,13 @@ func (b *DeploymentBuilder) Update(object client.Object) error {
 		})
 	}
 
-	deployment.Spec.Replicas = b.service.Replicas
+	// Manage replicas only when the CR sets them. Leaving the field unset lets an
+	// external autoscaler (HPA / KEDA) own the count: Update() mutates the live
+	// Deployment, so skipping the assignment preserves the autoscaler's current
+	// value instead of resetting it on every reconcile. Enables frontend scale-to-zero.
+	if b.service.Replicas != nil {
+		deployment.Spec.Replicas = b.service.Replicas
+	}
 
 	deployment.Spec.Selector = &metav1.LabelSelector{
 		MatchLabels: metadata.LabelsSelector(b.instance, b.serviceName),


### PR DESCRIPTION
## Summary

`DeploymentBuilder.Update()` mutated the live Deployment and unconditionally wrote `Spec.Replicas` on every reconcile, resetting the replica count chosen by an external autoscaler. This guards the assignment so it only runs when the CR sets `Replicas`; leaving it unset lets HPA/KEDA own the count — the operator-side enabler for frontend scale-to-zero.

## Change

`internal/resource/base/deployment_builder.go`: only assign `deployment.Spec.Replicas` when `b.service.Replicas != nil`.

## Behavior

- CRs that set `Replicas`: unchanged.
- CRs that leave `Replicas` nil: the operator no longer resets the count each reconcile, so an autoscaler can scale the external Temporal frontend to zero.

## Testing

- `go build ./...` passes.
- Follow-up: unit test for the nil-`Replicas` path (no test harness exists for this builder yet).

## Note for reviewers

This assumes `Replicas` can be `nil` at `Update()` time. If a defaulting webhook forces it non-nil, the guard is a no-op — worth confirming during review.

Linear: [ARUN-907](https://linear.app/atlan-epd/issue/ARUN-907/operator-dont-reset-deployment-replicas-on-reconcile-when-replicas-is)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
