### PR TITLE
feat: allow frontend to scale to zero replicas

### DIFF
--- a/api/v1beta1/temporalcluster_defaults.go
+++ b/api/v1beta1/temporalcluster_defaults.go
@@ -85,9 +85,10 @@ func (c *TemporalCluster) Default() {
 	if c.Spec.Services.Frontend == nil {
 		c.Spec.Services.Frontend = new(ServiceSpec)
 	}
-	if c.Spec.Services.Frontend.Replicas == nil {
-		c.Spec.Services.Frontend.Replicas = ptr.To[int32](1)
-	}
+	// Intentionally do not default Frontend.Replicas: leaving it unset lets an
+	// external autoscaler (HPA/KEDA) own the count and enables frontend
+	// scale-to-zero. The deployment builder only writes Spec.Replicas when this
+	// field is set, so an unset value defers to the autoscaler.
 	if c.Spec.Services.Frontend.Port == nil {
 		c.Spec.Services.Frontend.Port = ptr.To[int32](7233)
 	}

--- a/api/v1beta1/temporalcluster_types.go
+++ b/api/v1beta1/temporalcluster_types.go
@@ -86,7 +86,7 @@ type ServiceSpec struct {
 	// +optional
 	HTTPPort *int32 `json:"httpPort"`
 	// Number of desired replicas for the service. Default to 1.
-	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Minimum=0
 	// +optional
 	Replicas *int32 `json:"replicas"`
 	// Compute Resources required by this service.

--- a/bundle/manifests/temporal.io_temporalclusters.yaml
+++ b/bundle/manifests/temporal.io_temporalclusters.yaml
@@ -3361,7 +3361,7 @@ spec:
                         description: Number of desired replicas for the service. Default
                           to 1.
                         format: int32
-                        minimum: 1
+                        minimum: 0
                         type: integer
                       resources:
                         description: |-
@@ -3535,7 +3535,7 @@ spec:
                         description: Number of desired replicas for the service. Default
                           to 1.
                         format: int32
-                        minimum: 1
+                        minimum: 0
                         type: integer
                       resources:
                         description: |-
@@ -3716,7 +3716,7 @@ spec:
                         description: Number of desired replicas for the service. Default
                           to 1.
                         format: int32
-                        minimum: 1
+                        minimum: 0
                         type: integer
                       resources:
                         description: |-
@@ -3890,7 +3890,7 @@ spec:
                         description: Number of desired replicas for the service. Default
                           to 1.
                         format: int32
-                        minimum: 1
+                        minimum: 0
                         type: integer
                       resources:
                         description: |-
@@ -4131,7 +4131,7 @@ spec:
                         description: Number of desired replicas for the service. Default
                           to 1.
                         format: int32
-                        minimum: 1
+                        minimum: 0
                         type: integer
                       resources:
                         description: |-

--- a/charts/temporal-operator/crds/temporal-operator.crds.yaml
+++ b/charts/temporal-operator/crds/temporal-operator.crds.yaml
@@ -3354,7 +3354,7 @@ spec:
                         description: Number of desired replicas for the service. Default
                           to 1.
                         format: int32
-                        minimum: 1
+                        minimum: 0
                         type: integer
                       resources:
                         description: |-
@@ -3526,7 +3526,7 @@ spec:
                         description: Number of desired replicas for the service. Default
                           to 1.
                         format: int32
-                        minimum: 1
+                        minimum: 0
                         type: integer
                       resources:
                         description: |-
@@ -3705,7 +3705,7 @@ spec:
                         description: Number of desired replicas for the service. Default
                           to 1.
                         format: int32
-                        minimum: 1
+                        minimum: 0
                         type: integer
                       resources:
                         description: |-
@@ -3877,7 +3877,7 @@ spec:
                         description: Number of desired replicas for the service. Default
                           to 1.
                         format: int32
-                        minimum: 1
+                        minimum: 0
                         type: integer
                       resources:
                         description: |-
@@ -4114,7 +4114,7 @@ spec:
                         description: Number of desired replicas for the service. Default
                           to 1.
                         format: int32
-                        minimum: 1
+                        minimum: 0
                         type: integer
                       resources:
                         description: |-

--- a/config/crd/bases/temporal.io_temporalclusters.yaml
+++ b/config/crd/bases/temporal.io_temporalclusters.yaml
@@ -3065,7 +3065,7 @@ spec:
                         replicas:
                           description: Number of desired replicas for the service. Default to 1.
                           format: int32
-                          minimum: 1
+                          minimum: 0
                           type: integer
                         resources:
                           description: |-
@@ -3232,7 +3232,7 @@ spec:
                         replicas:
                           description: Number of desired replicas for the service. Default to 1.
                           format: int32
-                          minimum: 1
+                          minimum: 0
                           type: integer
                         resources:
                           description: |-
@@ -3405,7 +3405,7 @@ spec:
                         replicas:
                           description: Number of desired replicas for the service. Default to 1.
                           format: int32
-                          minimum: 1
+                          minimum: 0
                           type: integer
                         resources:
                           description: |-
@@ -3572,7 +3572,7 @@ spec:
                         replicas:
                           description: Number of desired replicas for the service. Default to 1.
                           format: int32
-                          minimum: 1
+                          minimum: 0
                           type: integer
                         resources:
                           description: |-
@@ -3802,7 +3802,7 @@ spec:
                         replicas:
                           description: Number of desired replicas for the service. Default to 1.
                           format: int32
-                          minimum: 1
+                          minimum: 0
                           type: integer
                         resources:
                           description: |-

--- a/webhooks/temporalcluster_webhook.go
+++ b/webhooks/temporalcluster_webhook.go
@@ -410,6 +410,46 @@ func (w *TemporalClusterWebhook) validateCluster(cluster *v1beta1.TemporalCluste
 			}
 		}
 	}
+
+	// Load-bearing services must run at least one replica. The public frontend may
+	// be scaled to zero (to disable external access or defer to an autoscaler), but
+	// history, matching, worker and the internal frontend are not optional. This
+	// guards the relaxed CRD minimum (0), which otherwise applies to every service.
+	if cluster.Spec.Services != nil {
+		mustRunServices := []primitives.ServiceName{
+			primitives.HistoryService,
+			primitives.MatchingService,
+			primitives.WorkerService,
+		}
+		for _, service := range mustRunServices {
+			spec, err := cluster.Spec.Services.GetServiceSpec(service)
+			if err != nil || spec == nil {
+				continue
+			}
+			if spec.Replicas != nil && *spec.Replicas < 1 {
+				errs = append(errs,
+					field.Invalid(
+						field.NewPath("spec", "services", string(service), "replicas"),
+						*spec.Replicas,
+						"replicas must be greater than or equal to 1 for this service",
+					),
+				)
+			}
+		}
+
+		if cluster.Spec.Services.InternalFrontend.IsEnabled() &&
+			cluster.Spec.Services.InternalFrontend.Replicas != nil &&
+			*cluster.Spec.Services.InternalFrontend.Replicas < 1 {
+			errs = append(errs,
+				field.Invalid(
+					field.NewPath("spec", "services", "internalFrontend", "replicas"),
+					*cluster.Spec.Services.InternalFrontend.Replicas,
+					"replicas must be greater than or equal to 1 when internal frontend is enabled",
+				),
+			)
+		}
+	}
+
 	return warns, errs
 }
 

--- a/webhooks/temporalcluster_webhook_test.go
+++ b/webhooks/temporalcluster_webhook_test.go
@@ -143,6 +143,21 @@ func TestDefault(t *testing.T) {
 	}
 }
 
+func TestDefaultReplicas(t *testing.T) {
+	c := &v1beta1.TemporalCluster{
+		TypeMeta:   v1beta1.TemporalClusterTypeMeta,
+		ObjectMeta: metav1.ObjectMeta{Name: "fake"},
+	}
+	c.Default()
+
+	// The frontend is intentionally left unset so an external autoscaler can own
+	// the count (enables scale-to-zero); the other services still default to 1.
+	assert.Nil(t, c.Spec.Services.Frontend.Replicas)
+	assert.Equal(t, int32(1), *c.Spec.Services.History.Replicas)
+	assert.Equal(t, int32(1), *c.Spec.Services.Matching.Replicas)
+	assert.Equal(t, int32(1), *c.Spec.Services.Worker.Replicas)
+}
+
 func TestValidateCreate(t *testing.T) {
 	tests := map[string]struct {
 		object      runtime.Object
@@ -335,6 +350,50 @@ func TestValidateCreate(t *testing.T) {
 				},
 			},
 			expectedErr: "Forbidden: Can't set JSONPatch when Spec is set on Deployment override",
+		},
+		"frontend can be scaled to zero": {
+			object: &v1beta1.TemporalCluster{
+				TypeMeta:   v1beta1.TemporalClusterTypeMeta,
+				ObjectMeta: metav1.ObjectMeta{Name: "fake"},
+				Spec: v1beta1.TemporalClusterSpec{
+					Version: version.MustNewVersionFromString("1.18.4"),
+					Services: &v1beta1.ServicesSpec{
+						Frontend: &v1beta1.ServiceSpec{Replicas: ptr.To[int32](0)},
+					},
+				},
+			},
+			wh: &webhooks.TemporalClusterWebhook{AvailableAPIs: &discovery.AvailableAPIs{}},
+		},
+		"history replicas below one is rejected": {
+			object: &v1beta1.TemporalCluster{
+				TypeMeta:   v1beta1.TemporalClusterTypeMeta,
+				ObjectMeta: metav1.ObjectMeta{Name: "fake"},
+				Spec: v1beta1.TemporalClusterSpec{
+					Version: version.MustNewVersionFromString("1.18.4"),
+					Services: &v1beta1.ServicesSpec{
+						History: &v1beta1.ServiceSpec{Replicas: ptr.To[int32](0)},
+					},
+				},
+			},
+			wh:          &webhooks.TemporalClusterWebhook{AvailableAPIs: &discovery.AvailableAPIs{}},
+			expectedErr: "spec.services.history.replicas",
+		},
+		"internal frontend replicas below one is rejected": {
+			object: &v1beta1.TemporalCluster{
+				TypeMeta:   v1beta1.TemporalClusterTypeMeta,
+				ObjectMeta: metav1.ObjectMeta{Name: "fake"},
+				Spec: v1beta1.TemporalClusterSpec{
+					Version: version.MustNewVersionFromString("1.29.4"),
+					Services: &v1beta1.ServicesSpec{
+						InternalFrontend: &v1beta1.InternalFrontendServiceSpec{
+							ServiceSpec: v1beta1.ServiceSpec{Replicas: ptr.To[int32](0)},
+							Enabled:     true,
+						},
+					},
+				},
+			},
+			wh:          &webhooks.TemporalClusterWebhook{AvailableAPIs: &discovery.AvailableAPIs{}},
+			expectedErr: "spec.services.internalFrontend.replicas",
 		},
 	}
 


### PR DESCRIPTION
## What

Lets the public Temporal frontend run at **0 replicas**, either explicitly (`replicas: 0`) or by leaving `replicas` unset so an external autoscaler (HPA/KEDA) owns the count. Completes the scale-to-zero work started in f7a3114.

## Why

`f7a3114` added a deployment-builder guard that skips writing `Spec.Replicas` when the CR leaves it unset, so an autoscaler can own the count. Two things undermined it:

- the CRD validation `Minimum=1` rejected an explicit `replicas: 0`, and
- the mutating webhook always defaulted `Frontend.Replicas` to 1, so the field was never nil at reconcile and the guard never fired.

## Changes

- **types.go** — `ServiceSpec.Replicas` validation `Minimum=1` → `Minimum=0`.
- **defaults.go** — stop defaulting `Frontend.Replicas` to 1 (unset now stays nil → builder defers to the autoscaler).
- **webhook.go** — guardrail: `history`, `matching`, `worker`, and `internal-frontend` (when enabled) must stay `>= 1`. Only the public frontend may be 0. Rationale: a 0-replica core service breaks the cluster and would falsely pass the upgrade hop-gate, since kstatus reports a 0-replica Deployment as `Ready`.
- **CRDs** — `config/crd/bases`, `charts/`, `bundle/`: the 5 service-replica `minimum` fields set to 0 (UI and all other fields untouched).

Only the public frontend is affected. With `internalFrontend` enabled, namespace/schedule reconciliation and internal system workflows keep working via internal-frontend; only external API access is lost when the frontend is at 0.

## Testing

- `go build ./...`, `go vet`, `gofmt`: clean.
- 154 unit tests pass. New: `TestDefaultReplicas` (frontend stays nil, core services default to 1) and three `TestValidateCreate` cases (frontend 0 allowed; history 0 and internal-frontend 0 rejected). Written test-first, confirmed red before implementing.

## Note on generated CRDs

`make manifests` does not build on Go 1.26 (`controller-gen@v0.16.3` pulls `golang.org/x/tools@v0.24.0`, which no longer compiles). The CRD change is therefore a scoped, description-preserving edit touching only the 5 service-replica `minimum` lines, so a proper `make manifests` / `make helm` / `make bundle` on a compatible toolchain reproduces it with no drift. `golangci-lint` was not run locally (not installed); CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
