### PR TITLE
ci: publish operator helm chart to ghcr OCI registry

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -75,3 +75,16 @@ jobs:
           tags: |
             ghcr.io/atlanhq/${{ github.event.repository.name }}-bundle-${{ steps.get_lowercase_branch.outputs.lowercase_branch }}:latest
             ghcr.io/atlanhq/${{ github.event.repository.name }}-bundle-${{ steps.get_lowercase_branch.outputs.lowercase_branch }}:${{ steps.get_version.outputs.version }}
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Generate operator chart
+        run: make helm
+
+      - name: Package and push operator chart to GHCR (OCI)
+        run: |
+          CHART_VERSION="0.6.0-${{ steps.get_version.outputs.version }}"
+          echo "${{ secrets.ORG_PAT_GITHUB }}" | helm registry login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
+          helm package charts/temporal-operator --version "$CHART_VERSION" --app-version "v$(cat VERSION)"
+          helm push "temporal-operator-${CHART_VERSION}.tgz" oci://${{ env.REGISTRY }}/atlanhq/charts


### PR DESCRIPTION
## What

Adds steps to the fork build workflow (`build.yaml`, on push to `main-0.22-atlan-0.1`) that package the operator Helm chart and push it to **`oci://ghcr.io/atlanhq/charts`**.

## Why

`build.yaml` already publishes the operator and bundle images to `ghcr.io/atlanhq`, but not the Helm chart. The chart carries the operator CRDs, and downstream (the atlan chart) needs to consume it from an OCI registry - especially now that #10 changes the `temporalclusters` CRD (`minimum: 0` on service replicas).

## How

- `make helm` regenerates the CRDs from the Go markers and refreshes `charts/temporal-operator/crds/`, so the packaged chart always carries the authoritative CRD.
- `helm package … --version 0.6.0-<sha>` tags the chart with the chart version plus the same short commit SHA the operator image already uses - correlated and immutable per commit.
- `helm push … oci://ghcr.io/atlanhq/charts` publishes `temporal-operator:0.6.0-<sha>`.
- Reuses the existing `ORG_PAT_GITHUB` credential already used for the image pushes (same registry/org, needs `packages:write`).

## Result

Each push to `main-0.22-atlan-0.1` now emits, SHA-correlated: operator image, bundle image, and `oci://ghcr.io/atlanhq/charts/temporal-operator:0.6.0-<sha>`. Merging #10 will be the first push that publishes a chart carrying the `minimum: 0` CRD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
