### PR TITLE
ci: pin Helm to v3.18.6 for OCI chart push

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -78,6 +78,11 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@v4
+        with:
+          # Pin to the last release before the Helm 4.x OCI/GHCR push regression
+          # (helm/helm#31223, #31600): 4.x fails `helm push` to ghcr.io with
+          # `failed to perform "Tag" on destination: ... not found`.
+          version: v3.18.6
 
       - name: Generate operator chart
         run: make helm


### PR DESCRIPTION
## What

Pin `azure/setup-helm@v4` to Helm **v3.18.6** in the chart-publish step.

## Why

The chart-publish step added in #11 failed on its first run:

```
Error: failed to perform "Tag" on destination: sha256:8ee4...: not found
```

`setup-helm@v4` with no version installs the latest Helm, which is now **v4.2.2**. Helm 4.x has a known regression pushing OCI charts to GHCR (helm/helm#31223, #31600, #32247); v3.18.6 is the last known-good release. Login and packaging succeeded - only the 4.x push/tag step failed - so pinning the version is the whole fix.

## Note

Only the chart step uses Helm; the operator and bundle image pushes were unaffected. Worth revisiting the pin once Helm 4.x fixes the GHCR push path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
