### PR TITLE
fix: omit empty replicas so unset frontend doesn't serialize as null

### DIFF
--- a/api/v1beta1/temporalcluster_types.go
+++ b/api/v1beta1/temporalcluster_types.go
@@ -88,7 +88,7 @@ type ServiceSpec struct {
 	// Number of desired replicas for the service. Default to 1.
 	// +kubebuilder:validation:Minimum=0
 	// +optional
-	Replicas *int32 `json:"replicas"`
+	Replicas *int32 `json:"replicas,omitempty"`
 	// Compute Resources required by this service.
 	// More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 	// +optional

--- a/api/v1beta1/temporalcluster_types_test.go
+++ b/api/v1beta1/temporalcluster_types_test.go
@@ -1,0 +1,41 @@
+// Licensed to Alexandre VILAIN under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Alexandre VILAIN licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package v1beta1_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/alexandrevilain/temporal-operator/api/v1beta1"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/ptr"
+)
+
+// A nil ServiceSpec.Replicas must serialize as omitted, not `"replicas":null`.
+// The CRD field is a non-nullable integer, so a null (which is what a nil
+// pointer without omitempty marshals to) is rejected on apply - this blocks
+// leaving the frontend replicas unset for scale-to-zero.
+func TestServiceSpecReplicasOmitEmpty(t *testing.T) {
+	unset, err := json.Marshal(v1beta1.ServiceSpec{})
+	assert.NoError(t, err)
+	assert.NotContains(t, string(unset), "replicas", "nil replicas must be omitted, not null")
+
+	zero, err := json.Marshal(v1beta1.ServiceSpec{Replicas: ptr.To[int32](0)})
+	assert.NoError(t, err)
+	assert.Contains(t, string(zero), `"replicas":0`, "explicit 0 must still be serialized")
+}


### PR DESCRIPTION
## Problem

Applying a TemporalCluster whose frontend leaves `replicas` unset fails CRD validation:

```
spec.services.frontend.replicas: Invalid value: "null": spec.services.frontend.replicas in body must be of type integer: "null"
```

This blocks the frontend scale-to-zero setup, which relies on leaving frontend replicas unset.

## Cause

`ServiceSpec.Replicas` is `*int32` tagged `json:"replicas"` - **no `omitempty`**. Before #10 the mutating webhook always defaulted frontend replicas to 1, so it was never nil. #10 removed that default (for scale-to-zero), so an unset frontend replicas is now nil, and the webhook round-trips it back as `"replicas": null`. The CRD field is a non-nullable integer, so `null` is rejected.

## Fix

Add `,omitempty` to `ServiceSpec.Replicas`: a nil value is omitted rather than serialized as `null`. Explicit `0` (minimum:0) and positive counts are unaffected. The field is already `+optional`, so the generated CRD schema does not change (the `required` list is unaffected).

## Follow-up

Needs a rebuild (new image + `0.6.0-<sha>` chart); the atlan operator-bump PRs (atlanhq/atlan#13825 / #13826 / #13827) get re-pointed to that new SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
