### PR TITLE
feat: scope operator cache to watched namespaces (ARUN-948)

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ package main
 import (
 	"flag"
 	"os"
+	"strings"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -29,6 +30,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
@@ -66,12 +68,15 @@ func main() {
 		metricsAddr          string
 		enableLeaderElection bool
 		probeAddr            string
+		watchNamespaces      string
 	)
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
+	flag.StringVar(&watchNamespaces, "watch-namespaces", "",
+		"Comma-separated list of namespaces to watch and cache. Empty means all namespaces (cluster-wide).")
 
 	opts := zap.Options{
 		Development: true,
@@ -83,6 +88,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: scheme,
+		Cache:  buildCacheOptions(watchNamespaces),
 		Metrics: metricsserver.Options{
 			BindAddress: metricsAddr,
 		},
@@ -161,4 +167,22 @@ func main() {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
+}
+
+// buildCacheOptions returns manager cache options scoped to the provided
+// comma-separated list of namespaces. An empty or whitespace-only value caches
+// all namespaces, preserving the default cluster-wide behavior.
+func buildCacheOptions(watchNamespaces string) cache.Options {
+	namespaces := map[string]cache.Config{}
+	for _, ns := range strings.Split(watchNamespaces, ",") {
+		if ns = strings.TrimSpace(ns); ns != "" {
+			namespaces[ns] = cache.Config{}
+		}
+	}
+
+	if len(namespaces) == 0 {
+		return cache.Options{}
+	}
+
+	return cache.Options{DefaultNamespaces: namespaces}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,68 @@
+// Licensed to Alexandre VILAIN under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Alexandre VILAIN licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+)
+
+func TestBuildCacheOptions(t *testing.T) {
+	tests := map[string]struct {
+		watchNamespaces string
+		expected        map[string]cache.Config
+	}{
+		"empty watches all namespaces": {
+			watchNamespaces: "",
+			expected:        nil,
+		},
+		"blank watches all namespaces": {
+			watchNamespaces: "  ",
+			expected:        nil,
+		},
+		"commas only watches all namespaces": {
+			watchNamespaces: ", ,",
+			expected:        nil,
+		},
+		"single namespace": {
+			watchNamespaces: "temporal",
+			expected:        map[string]cache.Config{"temporal": {}},
+		},
+		"multiple namespaces": {
+			watchNamespaces: "temporal,default",
+			expected:        map[string]cache.Config{"temporal": {}, "default": {}},
+		},
+		"trims surrounding whitespace": {
+			watchNamespaces: " temporal , default ",
+			expected:        map[string]cache.Config{"temporal": {}, "default": {}},
+		},
+		"ignores empty segments": {
+			watchNamespaces: "temporal,,default,",
+			expected:        map[string]cache.Config{"temporal": {}, "default": {}},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			opts := buildCacheOptions(tc.watchNamespaces)
+			assert.Equal(t, tc.expected, opts.DefaultNamespaces)
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds a `--watch-namespaces` flag that scopes the controller-runtime manager cache to a comma-separated set of namespaces via `cache.Options.DefaultNamespaces`. Empty (the default) keeps today's cluster-wide behavior, so this is inert until the flag is set.

## Why

The operator runs a cluster-wide informer cache, so it lists and watches every Secret and ConfigMap in the whole cluster. On real tenant object counts the cache sync exceeds 128Mi at startup - we already bumped the manager memory limit to 512Mi to cope (`atlan/charts/values.yaml`). Where all Temporal CRs live in one namespace (`temporal` in Atlan), scoping the cache there drops every out-of-namespace object.

## Why namespace-scoping, not label-scoping

- The operator reads no Secrets in the current config (datastore password is pod env-var injection; mTLS is off; no `TemporalClusterClient` CRs).
- If mTLS is enabled later, the cert-manager frontend cert Secrets live in `temporal` and carry none of the operator's `app.kubernetes.io` labels, so a label-scoped Secret cache would return NotFound for those reads. Namespace-scoping caches them correctly.
- Cluster-scoped resources stay globally cached, and leader election uses a non-cached client, so caching only `temporal` while the operator pod runs in `default` is safe.

## Test plan

- `go test ./ -run TestBuildCacheOptions` - new unit test for the parsing seam (empty/blank/commas-only → all namespaces; single/multiple/whitespace/empty-segments → scoped map).
- `go build ./...`, `go vet ./`, and `gofmt` clean on the changed files.
- `--watch-namespaces` appears in `--help`, so it parses before the manager touches a cluster.
- Not covered: a live/envtest assertion that a Secret in another namespace is truly excluded from the cache. Can add if wanted.

## Activate in Atlan

Add `--watch-namespaces=temporal` to the operator subchart's `manager.args` (`subcharts/temporal-operator/values.yaml`).

Linear: ARUN-948

🤖 Generated with [Claude Code](https://claude.com/claude-code)
