### PR TITLE
feat(chart): configurable controller-manager deploy strategy (ARUN-948)

### DIFF
--- a/charts/temporal-operator/templates/deployment.yaml
+++ b/charts/temporal-operator/templates/deployment.yaml
@@ -7,6 +7,10 @@ metadata:
   {{- include "temporal-operator.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.manager.replicas }}
+  {{- with .Values.manager.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/charts/temporal-operator/values.yaml
+++ b/charts/temporal-operator/values.yaml
@@ -2,6 +2,8 @@ manager:
   # -- Arguments to be passed to the controller manager container.
   args:
   - --leader-elect
+  # -- Deployment update strategy for the controller manager. Empty ({}) uses the Kubernetes default (RollingUpdate).
+  strategy: {}
   # -- Security context for the controller manager container.
   containerSecurityContext:
     # -- Disallow privilege escalation for the container.


### PR DESCRIPTION
## What

Adds a values-driven `manager.strategy` to the operator chart's controller-manager Deployment:

```yaml
{{- with .Values.manager.strategy }}
strategy:
  {{- toYaml . | nindent 4 }}
{{- end }}
```

Default is `{}`, which renders no `strategy` block and keeps the Kubernetes default (RollingUpdate) - so existing installs are unchanged.

## Why

For single-replica installs (e.g. Atlan, ARUN-948) we want `strategy: Recreate` so a rollout never runs two managers at once, which matters now that leader election is disabled there. Strategy is a template field, so it can't be set through a values override alone - the chart needs this hook. Consumers can then set `manager.strategy: {type: Recreate}` via umbrella values.

## Test

```
helm template t charts/temporal-operator --show-only templates/deployment.yaml
# -> no strategy block (RollingUpdate), unchanged

helm template t charts/temporal-operator --set manager.strategy.type=Recreate --show-only templates/deployment.yaml
# -> strategy:\n    type: Recreate
```

## Linear

ARUN-948

🤖 Generated with [Claude Code](https://claude.com/claude-code)
