### PR TITLE
feat: support Temporal Server 1.30.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Please note this table only reports end-to-end tests suite coverage, others vers
 
 | Temporal Operator      | Temporal           | Kubernetes     |
 |------------------------|--------------------|----------------|
-| v0.22.x (not released) | v1.24.x to v1.28.x | v1.30 to v1.33 |
+| v0.22.x (not released) | v1.24.x to v1.30.x | v1.30 to v1.33 |
 | v0.21.x                | v1.20.x to v1.25.x | v1.27 to v1.31 |
 | v0.20.x                | v1.19.x to v1.24.x | v1.26 to v1.30 |
 | v0.19.x                | v1.19.x to v1.23.x | v1.25 to v1.29 |

--- a/internal/resource/base/deployment_builder.go
+++ b/internal/resource/base/deployment_builder.go
@@ -29,6 +29,7 @@ import (
 	"github.com/alexandrevilain/temporal-operator/internal/resource/persistence"
 	"github.com/alexandrevilain/temporal-operator/internal/resource/prometheus"
 	"github.com/alexandrevilain/temporal-operator/pkg/kubernetes"
+	"github.com/alexandrevilain/temporal-operator/pkg/version"
 	"go.temporal.io/server/common/primitives"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -120,6 +121,23 @@ func (b *DeploymentBuilder) Update(object client.Object) error {
 			Name:  "SERVICES",
 			Value: b.serviceName,
 		},
+	}
+
+	// Temporal Server >= 1.30 removed dockerize from the server image. The service
+	// to start is selected via TEMPORAL_SERVICES and the (sprig) config template is
+	// located via TEMPORAL_SERVER_CONFIG_FILE_PATH. The legacy SERVICES env var is
+	// kept above for the metrics "type" tag and pre-1.30 images.
+	if b.instance.Spec.Version.GreaterOrEqual(version.V1_30_0) {
+		envVars = append(envVars,
+			corev1.EnvVar{
+				Name:  "TEMPORAL_SERVICES",
+				Value: b.serviceName,
+			},
+			corev1.EnvVar{
+				Name:  "TEMPORAL_SERVER_CONFIG_FILE_PATH",
+				Value: "/etc/temporal/config/config_template.yaml",
+			},
+		)
 	}
 
 	datastores := b.instance.Spec.Persistence.GetDatastores()

--- a/internal/resource/config/configmap_builder.go
+++ b/internal/resource/config/configmap_builder.go
@@ -63,6 +63,30 @@ func NewConfigmapBuilder(instance *v1beta1.TemporalCluster, scheme *runtime.Sche
 	}
 }
 
+// envPlaceholder returns a config-template placeholder resolving the given
+// environment variable at server startup.
+//
+// Temporal Server >= 1.30 removed dockerize and renders config templates with an
+// embedded sprig engine (dockerize is gone from the image). The dockerize-style
+// "{{ .Env.NAME }}" syntax no longer resolves and must be replaced by the sprig
+// "{{ env \"NAME\" }}" function.
+func (b *ConfigmapBuilder) envPlaceholder(name string) string {
+	if b.instance.Spec.Version.GreaterOrEqual(version.V1_30_0) {
+		return fmt.Sprintf(`{{ env "%s" }}`, name)
+	}
+	return fmt.Sprintf("{{ .Env.%s }}", name)
+}
+
+// broadcastAddressPlaceholder returns the membership broadcast address template,
+// defaulting to 0.0.0.0 when POD_IP is unset, using the templating syntax
+// supported by the target Temporal Server version.
+func (b *ConfigmapBuilder) broadcastAddressPlaceholder() string {
+	if b.instance.Spec.Version.GreaterOrEqual(version.V1_30_0) {
+		return `{{ default "0.0.0.0" (env "POD_IP") }}`
+	}
+	return `{{ default .Env.POD_IP "0.0.0.0" }}`
+}
+
 func (b *ConfigmapBuilder) Build() client.Object {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -86,17 +110,17 @@ func (b *ConfigmapBuilder) buildDatastoreConfig(store *v1beta1.DatastoreSpec) (*
 		v1beta1.MySQLDatastore,
 		v1beta1.MySQL8Datastore:
 		cfg.SQL = persistence.NewSQLConfigFromDatastoreSpec(store)
-		cfg.SQL.Password = fmt.Sprintf("{{ .Env.%s }}", store.GetPasswordEnvVarName())
+		cfg.SQL.Password = b.envPlaceholder(store.GetPasswordEnvVarName())
 	case v1beta1.CassandraDatastore:
 		cfg.Cassandra = persistence.NewCassandraConfigFromDatastoreSpec(store)
-		cfg.Cassandra.Password = fmt.Sprintf("{{ .Env.%s }}", store.GetPasswordEnvVarName())
+		cfg.Cassandra.Password = b.envPlaceholder(store.GetPasswordEnvVarName())
 	case v1beta1.ElasticsearchDatastore:
 		esCfg, err := persistence.NewElasticsearchConfigFromDatastoreSpec(store)
 		if err != nil {
 			return nil, fmt.Errorf("can't get elasticsearch config: %w", err)
 		}
 		cfg.Elasticsearch = esCfg
-		cfg.Elasticsearch.Password = fmt.Sprintf("{{ .Env.%s }}", store.GetPasswordEnvVarName())
+		cfg.Elasticsearch.Password = b.envPlaceholder(store.GetPasswordEnvVarName())
 	case v1beta1.UnknownDatastore:
 		return nil, errors.New("unknown datastore")
 	}
@@ -215,7 +239,7 @@ func (b *ConfigmapBuilder) Update(object client.Object) error {
 	temporalCfg.Global = temporalconfig.Global{
 		Membership: temporalconfig.Membership{
 			MaxJoinDuration:  30 * time.Second,
-			BroadcastAddress: "{{ default .Env.POD_IP \"0.0.0.0\" }}",
+			BroadcastAddress: b.broadcastAddressPlaceholder(),
 		},
 		Authorization: authorization.ToTemporalAuthorization(b.instance.Spec.Authorization),
 	}
@@ -314,7 +338,7 @@ func (b *ConfigmapBuilder) Update(object client.Object) error {
 	if b.instance.Spec.Metrics.IsEnabled() {
 		temporalCfg.Global.Metrics = &metrics.Config{
 			ClientConfig: metrics.ClientConfig{
-				Tags: map[string]string{"type": "{{ .Env.SERVICES }}"},
+				Tags: map[string]string{"type": b.envPlaceholder("SERVICES")},
 			},
 		}
 
@@ -441,8 +465,19 @@ func (b *ConfigmapBuilder) Update(object client.Object) error {
 		return fmt.Errorf("failed marshaling temporal config: %w", err)
 	}
 
+	renderedConfig := string(result)
+
+	// Temporal Server >= 1.30 renders config templates with an embedded sprig
+	// engine (dockerize was removed from the image). Templating is only activated
+	// when the file starts with an "enable-template" comment within its first 1KB,
+	// and the server locates it via TEMPORAL_SERVER_CONFIG_FILE_PATH (set on the
+	// server Deployment).
+	if b.instance.Spec.Version.GreaterOrEqual(version.V1_30_0) {
+		renderedConfig = "# enable-template\n" + renderedConfig
+	}
+
 	configMap.Data = map[string]string{
-		"config_template.yaml": string(result),
+		"config_template.yaml": renderedConfig,
 	}
 
 	if err := controllerutil.SetControllerReference(b.instance, configMap, b.scheme); err != nil {

--- a/internal/resource/config/configmap_builder_internal_test.go
+++ b/internal/resource/config/configmap_builder_internal_test.go
@@ -1,0 +1,51 @@
+// Licensed to Alexandre VILAIN under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Alexandre VILAIN licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package config
+
+import (
+	"testing"
+
+	"github.com/alexandrevilain/temporal-operator/api/v1beta1"
+	"github.com/alexandrevilain/temporal-operator/pkg/version"
+	"github.com/stretchr/testify/assert"
+)
+
+// builderForVersion returns a ConfigmapBuilder whose cluster targets the given
+// Temporal server version, enough to exercise the version-gated template helpers.
+func builderForVersion(v string) *ConfigmapBuilder {
+	return &ConfigmapBuilder{
+		instance: &v1beta1.TemporalCluster{
+			Spec: v1beta1.TemporalClusterSpec{
+				Version: version.MustNewVersionFromString(v),
+			},
+		},
+	}
+}
+
+func TestEnvPlaceholderSyntaxByVersion(t *testing.T) {
+	// Pre-1.30 images render config with dockerize (.Env syntax); 1.30+ renders
+	// with the server binary's embedded sprig (env function).
+	assert.Equal(t, `{{ .Env.POSTGRES_PWD }}`, builderForVersion("1.29.4").envPlaceholder("POSTGRES_PWD"))
+	assert.Equal(t, `{{ env "POSTGRES_PWD" }}`, builderForVersion("1.30.6").envPlaceholder("POSTGRES_PWD"))
+	// Boundary: 1.30.0 itself is on the sprig side of the gate.
+	assert.Equal(t, `{{ env "SERVICES" }}`, builderForVersion("1.30.0").envPlaceholder("SERVICES"))
+}
+
+func TestBroadcastAddressPlaceholderByVersion(t *testing.T) {
+	assert.Equal(t, `{{ default .Env.POD_IP "0.0.0.0" }}`, builderForVersion("1.29.4").broadcastAddressPlaceholder())
+	assert.Equal(t, `{{ default "0.0.0.0" (env "POD_IP") }}`, builderForVersion("1.30.6").broadcastAddressPlaceholder())
+}

--- a/pkg/version/upgrade.go
+++ b/pkg/version/upgrade.go
@@ -35,6 +35,7 @@ var RecommendedVersions = map[uint64]string{
 	27: "1.27.4",
 	28: "1.28.2",
 	29: "1.29.4",
+	30: "1.30.6",
 }
 
 // NextUpgradeHop returns the next intermediate version to upgrade to,

--- a/pkg/version/upgrade_test.go
+++ b/pkg/version/upgrade_test.go
@@ -56,6 +56,16 @@ func TestNextUpgradeHop(t *testing.T) {
 			target:      "1.29.4",
 			expectedHop: "1.29.4",
 		},
+		"single hop 1.29 to 1.30": {
+			current:     "1.29.4",
+			target:      "1.30.6",
+			expectedHop: "1.30.6",
+		},
+		"multi-hop 1.28 to 1.30 uses 1.29 registry entry": {
+			current:     "1.28.2",
+			target:      "1.30.6",
+			expectedHop: "1.29.4",
+		},
 		"current already at target minor": {
 			current:     "1.29.0",
 			target:      "1.29.4",

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -28,7 +28,7 @@ import (
 
 var (
 	// SupportedVersionsRange holds all supported temporal versions.
-	SupportedVersionsRange  = mustNewConstraint(">= 1.14.0 < 1.30.0")
+	SupportedVersionsRange  = mustNewConstraint(">= 1.14.0 < 1.31.0")
 	ForbiddenBrokenReleases = []*Version{
 		// v1.21.0 is reported as broken, see: https://github.com/temporalio/temporal/releases/tag/v1.21.0
 		MustNewVersionFromString("1.21.0"),
@@ -38,6 +38,8 @@ var (
 		MustNewVersionFromString("1.24.0"),
 		// v1.27.0 is reported as broken, see: https://github.com/temporalio/temporal/releases/tag/v1.27.0
 		MustNewVersionFromString("1.27.0"),
+		// v1.30.0 has no published GitHub release (silently skipped upstream); use v1.30.1+.
+		MustNewVersionFromString("1.30.0"),
 	}
 	V1_18_0 = MustNewVersionFromString("1.18.0") //nolint:stylecheck,revive
 	V1_20_0 = MustNewVersionFromString("1.20.0") //nolint:stylecheck,revive
@@ -46,6 +48,9 @@ var (
 	V1_23_0 = MustNewVersionFromString("1.23.0") //nolint:stylecheck,revive
 	V1_24_0 = MustNewVersionFromString("1.24.0") //nolint:stylecheck,revive
 	V1_25_0 = MustNewVersionFromString("1.25.0") //nolint:stylecheck,revive
+	// V1_30_0 marks the boundary where Temporal removed dockerize and moved config
+	// templating into the server binary (embedded sprig). See configmap_builder.
+	V1_30_0 = MustNewVersionFromString("1.30.0") //nolint:stylecheck,revive
 )
 
 // Version is a wrapper around semver.Version which supports correct

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -24,6 +24,31 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestValidateSupportedRange(t *testing.T) {
+	tests := map[string]struct {
+		version     string
+		expectError bool
+	}{
+		"1.29.4 supported":     {version: "1.29.4", expectError: false},
+		"1.30.0 supported":     {version: "1.30.0", expectError: false},
+		"1.30.6 supported":     {version: "1.30.6", expectError: false},
+		"1.31.0 not supported": {version: "1.31.0", expectError: true},
+		"below floor 1.13.0":   {version: "1.13.0", expectError: true},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(tt *testing.T) {
+			v := version.MustNewVersionFromString(test.version)
+			err := v.Validate()
+			if test.expectError {
+				assert.Error(tt, err)
+				return
+			}
+			assert.NoError(tt, err)
+		})
+	}
+}
+
 func TestUpgradeConstraint(t *testing.T) {
 	tests := map[string]struct {
 		version        *version.Version


### PR DESCRIPTION
# feat: support Temporal Server 1.30.x

## Problem
Temporal Server 1.30 slimmed the `temporalio/server` image: `dockerize` was removed and config templating moved **into the server binary** (embedded `sprig`, opt-in via a leading `# enable-template` comment, and the config file located via `TEMPORAL_SERVER_CONFIG_FILE_PATH`). The operator mounts an *unrendered* `config_template.yaml` and sets no start command, so on a stock 1.30 image the dockerize-style `{{ .Env.X }}` placeholders never resolve and every server pod crash-loops. The version webhook also caps supported versions below 1.30.

## Changes
- **version** (`pkg/version/version.go`, `upgrade.go`): widen `SupportedVersionsRange` to `< 1.31.0`; add `30 -> 1.30.6` to `RecommendedVersions`; add the `V1_30_0` boundary constant; mark `1.30.0` broken (it has no published GitHub release — use `1.30.1+`).
- **config** (`internal/resource/config/configmap_builder.go`): for clusters `>= 1.30`, emit `sprig` placeholders (`{{ env "X" }}`, `{{ default "0.0.0.0" (env "POD_IP") }}`) and prepend the `# enable-template` marker. Pre-1.30 dockerize `.Env` behavior is unchanged (version-gated).
- **deployment** (`internal/resource/base/deployment_builder.go`): for `>= 1.30`, set `TEMPORAL_SERVICES` (service selection) and `TEMPORAL_SERVER_CONFIG_FILE_PATH` on the server container.

Scoped to what 1.30.x needs. This mirrors the config-rendering approach in upstream PR alexandrevilain/temporal-operator#987, but deliberately omits its 1.31-only pieces (the `PasswordCommand` datastore field and the Elasticsearch-tool schema changes), since this fork targets 1.30.6 with Postgres visibility.

## Testing
- `go build` / `go vet` clean on `pkg/version`, `internal/resource/config`, `internal/resource/base`.
- New unit tests: version range/upgrade-hop cases for 1.30; version-gated template-helper tests (`configmap_builder_internal_test.go`) asserting dockerize syntax pre-1.30 and sprig syntax `>= 1.30`.
- Rendering validated out-of-band: the emitted `sprig` template renders with nil template data (the way the server invokes it) — env vars resolve and `POD_IP` falls back to `0.0.0.0`, no placeholders left.

## Note on base branch
Targets `main-0.22-atlan-0.1` (the fork's active line — the branch `build.yaml` publishes the operator image from), consistent with the other operator PRs on this line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
